### PR TITLE
Support for urlencoded filenames

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,7 @@
 import json
 import os,sys,webbrowser
 import subprocess
+import urllib
 from wox import Wox
 from os import listdir
 from os.path import isfile, join
@@ -10,7 +11,7 @@ class Kitty(Wox):
 
     def load_session(self,kitty_path):
         session_path = os.path.join(kitty_path,"Sessions")
-        files = [f for f in listdir(session_path) if isfile(join(session_path,f))]
+        files = [urllib.unquote(f) for f in listdir(session_path) if isfile(join(session_path,f))]
         return files
 
     def query(self,query):


### PR DESCRIPTION
If there are some characters in the session file name (like ' ' or ':'), it's url encoded (like server%20192.168.1.15%3A9130).
It causes two problems:
- It looks ugly
- It doesn't open the session, since it should be decoded in the command (putty -load "decoded name here")

It's fixed by using urllib.unquote(f)
